### PR TITLE
Add unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "symfony/yaml": "4.3.*"
     },
     "require-dev": {
+        "symfony/phpunit-bridge": "^4.3"
     },
     "config": {
         "preferred-install": {

--- a/src/Model/Edge.php
+++ b/src/Model/Edge.php
@@ -10,22 +10,23 @@ namespace App\Model;
  */
 class Edge
 {
-    /** @var int */
+    /** @var mixed */
     private $fromNodeId;
-    /** @var int */
+    /** @var mixed */
     private $toNodeId;
 
     /**
-     * Edge constructor must be defined by two non zero integers.
+     * Edge constructor must be defined by two non null primitive typed
+     * identifiers.
      *
-     * @param int $from the id of the outgoing node
-     * @param int $to the id of the incoming node
+     * @param mixed $from the id of the outgoing node
+     * @param mixed $to the id of the incoming node
      * @throws \Exception
      */
     public function __construct($from, $to)
     {
-        if (0 === $from * $to) {
-            throw new \Exception('The IDs of both nodes must not be 0', 500);
+        if (null == $from || null == $to) {
+            throw new \Exception('The IDs of both nodes must not be null', 500);
         }
 
         $this->fromNodeId = $from;
@@ -33,17 +34,17 @@ class Edge
     }
 
     /**
-     * @return int
+     * @return mixed
      */
-    public function getFromNodeId()
+    public final function getFromNodeId()
     {
         return $this->fromNodeId;
     }
 
     /**
-     * @return int
+     * @return mixed
      */
-    public function getToNodeId()
+    public final function getToNodeId()
     {
         return $this->toNodeId;
     }

--- a/src/Model/Graph.php
+++ b/src/Model/Graph.php
@@ -98,7 +98,6 @@ class Graph
             // Fetch all edges and check if current node is in the toNodeId but not in the fromNodeId.
             $isParent = false;
             $isChild  = false;
-
             /** @var Edge $edge */
             foreach ($this->edges as $edge) {
                 if ($node->getId() == $edge->getFromNodeId()) {
@@ -114,7 +113,6 @@ class Graph
                 $leafNodes[] = $node;
             }
         }
-
         return $leafNodes;
     }
 
@@ -133,11 +131,13 @@ class Graph
         foreach ($this->getRootNodes() as $rootNode) {
             if (!$this->findCirclesByNodeId($rootNode->getId())) {
 
-                $pathLengh = $this->getPathLength($rootNode->getId(), 0);
+                $pathLength = $this->getPathLength($rootNode->getId(), 0);
 
-                if ($maxPathLength < $pathLengh) {
-                    $maxPathLength = $pathLengh;
+                if ($maxPathLength < $pathLength) {
+                    $maxPathLength = $pathLength;
                 }
+            } else {
+                throw new \Exception('Graph has at least one circular path. Cannot determine max depth.');
             }
         }
 
@@ -185,7 +185,8 @@ class Graph
     }
 
     /**
-     * Checks whether a node with given nodeId is a leaf.
+     * Checks whether a node with given nodeId is a leaf. A leaf is per definition a
+     * node that has at least one parent but no children.
      *
      * @param int $nodeId
      * @return bool
@@ -248,8 +249,9 @@ class Graph
     }
 
     /**
-     * Finds all circular paths starting from the root nodes.
-     * The returned array only stores the IDs of the nodes.
+     * Finds all circular paths for each node in the graph.
+     * The returned array only stores the IDs of the nodes that belong
+     * to the path that describes a circle.
      *
      * @return array
      */
@@ -310,8 +312,8 @@ class Graph
 
         // Add current nodeId to the set of already visited node IDs and recursively
         // check sub paths.
-        $visited[] = $nodeId;
         foreach ($this->findChildrenEdges($nodeId) as $edge) {
+            $visited[] = $nodeId;
             $visited = $this->findCirclesByNodeId($edge->getToNodeId(), $visited);
         }
 

--- a/src/Model/Node.php
+++ b/src/Model/Node.php
@@ -9,21 +9,21 @@ namespace App\Model;
  */
 class Node
 {
-    /** @var int */
+    /** @var mixed */
     private $id;
 
     /**
      * Node constructor requires an identifier that must be unique across a graph.
      *
-     * @param int $id
+     * @param mixed $id
      */
-    public function __construct(int $id)
+    public function __construct($id)
     {
         $this->id = $id;
     }
 
     /**
-     * @return int
+     * @return mixed
      */
     public function getId()
     {

--- a/tests/Model/GraphTest.php
+++ b/tests/Model/GraphTest.php
@@ -1,0 +1,394 @@
+<?php
+
+namespace App\Tests\Model;
+
+use App\Model\Edge;
+use App\Model\Graph;
+use App\Model\Node;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class GraphTest
+ *
+ * @group Model
+ * @group Model_Graph
+ *
+ * @package App\Tests\Model
+ */
+class GraphTest extends TestCase
+{
+    public function testAddEdge()
+    {
+        $graph = new Graph();
+        $edges = $graph->getEdges();
+        $this->assertEmpty($edges);
+        $graph->addEdge(new Edge(1, 2));
+        $edges = $graph->getEdges();
+        $this->assertNotEmpty($edges);
+    }
+
+    /**
+     * Tests the circularity of graphs.
+     * First graph has a circular path 3->6->7->3. The second graph has no
+     * circular paths. The third graph references a node within the second sub
+     * graph, but also doesn't result in a circle.
+     */
+    public function testHasCircularPaths()
+    {
+        /*
+         *        1
+         *       / \
+         *      2   3 <- 7
+         *     /   / \  /
+         *    4   5   6
+         */
+        $nodes = [1, 2, 3, 4, 5, 6, 7];
+        $edges = [[1, 2], [2, 4], [1, 3], [3, 5], [3, 6], [6, 7], [7, 3]];
+        $graph = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+
+        $this->assertTrue($graph->hasCircularPaths(),
+            "Graph was expected to have a circular path");
+
+        /*
+         *        1
+         *       / \
+         *      2   3
+         *     /   / \
+         *    4   5   6
+         *             \
+         *              7
+         */
+        $nodes = [1, 2, 3, 4, 5, 6, 7];
+        $edges = [[1, 2], [2, 4], [1, 3], [3, 5], [3, 6], [6, 7]];
+        $graph = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+
+        $this->assertFalse($graph->hasCircularPaths(),
+            'Graph was not expected to have a circular path');
+
+        /*
+        *        1
+        *       / \
+        *      2 - 3
+        *     / \ / \
+        *    4   5   6
+        */
+        $nodes = [1, 2, 3, 4, 5, 6];
+        $edges = [[1, 2], [2, 4], [2, 5], [2, 3], [1, 3], [3, 5], [3, 6]];
+        $graph = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+
+        $this->assertFalse($graph->hasCircularPaths(),
+            'Graph was not expected to have a circular path');
+    }
+
+    /**
+     * Test the isLeaf function, which expects to return true if, and only if
+     * a node has a parent but no children. In any other case it returns false.
+     *
+     * @throws \Exception
+     */
+    public function testIsLeaf()
+    {
+        /*
+         *  1   2
+         *  |
+         *  3
+         *
+         * Node 1 directs to node 3 which is a leaf but node 2 is an orphan and doesn't have neither a child nor
+         * a parent and should not be a leaf.
+         */
+        $nodes = [1, 2, 3];
+        $edges = [[1, 3]];
+        $graph = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+        // Root node
+        $this->assertFalse($graph->isLeaf(1));
+        // Leaf node
+        $this->assertTrue($graph->isLeaf(3));
+        // Orphan
+        $this->assertFalse($graph->isLeaf(2));
+    }
+
+    /**
+     * Tests the getRootNodes function which is expected to return only nodes
+     * that have no parent but at least one child.
+     */
+    public function testGetRootNodes()
+    {
+        /*
+         * simple tree structure:
+         *  1
+         *  |
+         *  2
+         * expected [1]
+         */
+        $graph     = new Graph([new Node(1), new Node(2)], [new Edge(1, 2)]);
+        $rootNodes = $graph->getRootNodes();
+
+        $this->assertEquals([new Node(1)], $rootNodes, 'Expected root node does not match');
+
+        /*
+         * One child with two root nodes
+         *   1   2
+         *    \ /
+         *     3
+         * expected [1,2]
+         */
+        $nodes     = [1, 2, 3];
+        $edges     = [[1, 3], [2, 3]];
+        $graph     = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+        $rootNodes = $graph->getRootNodes();
+        $this->assertEquals([new Node(1), new Node(2)], $rootNodes);
+
+        /*
+         * No root node. One orphan node and one circular path
+         *
+         *       1 -> 2 -> 1
+         *       3
+         */
+        $nodes = [1, 2, 3];
+        $edges = [[1, 2], [2, 1]];
+        $graph = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+        $this->assertEmpty($graph->getRootNodes());
+    }
+
+    /**
+     * Tests the getLeafNodes function which is expected to return only nodes
+     * that have at least one parent but no children nodes.
+     */
+    public function testGetLeafNodes()
+    {
+        /*
+         * simple tree structure:
+         *  1
+         *  |
+         *  2
+         * expected [2]
+         */
+        $graph     = new Graph([new Node(1), new Node(2)], [new Edge(1, 2)]);
+        $rootNodes = $graph->getLeafNodes();
+
+        $this->assertEquals([new Node(2)], $rootNodes, 'Expected leaf node does not match');
+
+        /*
+         * One child with two root nodes
+         *   1   2
+         *    \ /
+         *     3
+         * expected [3]
+         */
+        $nodes     = [1, 2, 3];
+        $edges     = [[1, 3], [2, 3]];
+        $graph     = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+        $rootNodes = $graph->getLeafNodes();
+        $this->assertEquals([new Node(3)], $rootNodes);
+
+        /*
+         * No leaf node. One orphan node and one circular path
+         *
+         *       1 -> 2 -> 1
+         *       3
+         */
+        $nodes = [1, 2, 3];
+        $edges = [[1, 2], [2, 1]];
+        $graph = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+        $this->assertEmpty($graph->getLeafNodes());
+    }
+
+    /**
+     * Tests the getMaxDepth function.
+     * @throws \Exception
+     */
+    public function testGetMaxDepth()
+    {
+        /*
+         * Simple graph:
+         *   1
+         *   |
+         *   2
+         * expected: 1
+         */
+        $nodes = [1, 2];
+        $edges = [[1, 2]];
+        $graph = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+        $this->assertEquals(1, $graph->getMaxDepth());
+
+        /*
+         * Simple graph with two root nodes:
+         *   1   2
+         *    \ /
+         *     3
+         * expected: 1
+         */
+        $nodes = [1, 2, 3];
+        $edges = [[1, 3], [2, 3]];
+        $graph = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+        $this->assertEquals(1, $graph->getMaxDepth());
+
+        /*
+         * Simple graph with two sub graphs:
+         *       1
+         *      / \
+         *     2   3
+         *          \
+         *           4
+         * expected: 2
+         */
+        $nodes = [1, 2, 3, 4];
+        $edges = [[1, 2], [1, 3], [3, 4]];
+        $graph = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+        $this->assertEquals(2, $graph->getMaxDepth());
+
+        /*
+         * Expected exception when graph has circular paths
+         *  1 -> 2 -> 3 -> 2
+         */
+        $this->expectExceptionMessage('Graph has at least one circular path. Cannot determine max depth.');
+        $nodes = [1, 2, 3];
+        $edges = [[1, 2], [2, 3], [3, 2]];
+        $graph = new Graph($this->createNodes($nodes), $this->createEdges($edges));
+        $graph->getMaxDepth();
+    }
+
+    /**
+     * Tests findAllCircularPaths method. This method expects all paths that
+     * result in a circular graph.
+     * @throws \Exception
+     */
+    public function testFindAllCircularPaths()
+    {
+        /*
+         * Empty array if no circular paths can be found.
+         */
+        $nodes = $this->createNodes([1, 2, 3, 4]);
+        $edges = $this->createEdges([[1, 2], [2, 3], [1, 4]]);
+        $graph = new Graph($nodes, $edges);
+        $this->assertEmpty($graph->findAllCircularPaths());
+
+        /*
+         * A circular graph:
+         * 1 -> 2 -> 3 -> 2
+         *
+         * The paths that are resulting in a circular path are:
+         * 1, 2, 3, 2
+         * 2, 3, 2
+         * 3, 2, 3
+         */
+        $nodes         = $this->createNodes([1, 2, 3,]);
+        $edges         = $this->createEdges([[1, 2], [2, 3], [3, 2]]);
+        $graph         = new Graph($nodes, $edges);
+        $circularPaths = $graph->findAllCircularPaths();
+        $expectedPaths = [
+            [1, 2, 3, 2],
+            [2, 3, 2],
+            [3, 2, 3],
+        ];
+        $this->assertEquals($expectedPaths, $circularPaths);
+    }
+
+    /**
+     * Test getEdges.
+     * @throws \Exception
+     */
+    public function testGetEdges()
+    {
+        $graph = new Graph();
+        $this->assertEmpty($graph->getEdges());
+        $graph->addEdge(new Edge(1, 2));
+        $this->assertEquals([new Edge(1, 2)], $graph->getEdges());
+    }
+
+    /**
+     * Tests findChildrenNodes which is expected to return all direct children of a
+     * node.
+     *
+     * @throws \Exception
+     */
+    public function testFindChildrenNodes()
+    {
+        /*
+         * A graph with one root node that has 4 children:
+         *          1
+         *       / / \  \
+         *      2  3  4  5
+         */
+        $nodes = $this->createNodes([1, 2, 3, 4, 5]);
+
+        $edges         = $this->createEdges([[1, 2], [1, 3], [1, 4], [1, 5]]);
+        $graph         = new Graph($nodes, $edges);
+        $expectedNodes = $this->createNodes([2, 3, 4, 5]);
+        $this->assertEquals($expectedNodes, $graph->findChildrenNodes(1));
+
+        /*
+         * A leaf node is expected not to have any children. Therefor the expected
+         * array is empty.
+         */
+        $this->assertEmpty($graph->findChildrenNodes(2));
+    }
+
+    /**
+     * Tests findOrphans which is expected to return an array of nodes that have neither
+     * a parent nor a child.
+     *
+     * @throws \Exception
+     */
+    public function testFindOrphans()
+    {
+        /*
+         * No edges between any of the existing nodes. So all nodes are
+         * orphans
+         */
+        $nodes = $this->createNodes([1, 2, 3]);
+        $graph = new Graph($nodes, []);
+        $graph->findOrphans();
+        $this->assertEquals($nodes, $graph->findOrphans());
+        // Lets add one edge between 1 and 3. Now we should have only one remaining orphan.
+        $graph->addEdge(new Edge(1, 3));
+        $this->assertEquals([new Node(2)], $graph->findOrphans());
+    }
+
+    /**
+     * Tests getNodes method.
+     */
+    public function testGetNodes()
+    {
+        $nodes = $this->createNodes([1, 2, 3]);
+        $graph = new Graph($nodes, []);
+        $this->assertEquals($nodes, $graph->getNodes());
+    }
+
+    /**
+     * Helper function to create an array of Edge objects by the given array of
+     * 2-element arrays.
+     *
+     * @param array $edgeArray
+     * @return array
+     * @throws \Exception
+     */
+    private function createEdges(array $edgeArray)
+    {
+        $edges = [];
+        foreach ($edgeArray as $edge) {
+            if (is_array($edge) && count($edge) == 2) {
+                $edges[] = new Edge($edge[0], $edge[1]);
+            }
+        }
+
+        return $edges;
+    }
+
+    /**
+     * Helper function to create an array of Node objects by the a given
+     * array of IDs.
+     *
+     * @param array $nodeIds
+     * @return array
+     */
+    private function createNodes(array $nodeIds)
+    {
+        $nodes = [];
+        foreach ($nodeIds as $nodeId) {
+            $nodes[] = new Node($nodeId);
+        }
+
+        return $nodes;
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for `App\Model\Graph` and resolves a few issues that were found. 
Additionally I removed the requirement of edges and nodes to be initialised with `integers`. This can be enforced by overriding classes.  